### PR TITLE
Initial implementation of adapting and copying dataset.xhtml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 letsencrypt
+utils/dataverse/mounts/dataset_commented.xhtml

--- a/setup.sh
+++ b/setup.sh
@@ -93,10 +93,11 @@ echo "--- Sign up options turned off!"
 echo "--- Copying dataset.xhtml with file and version tab removed..."
 # test if we have the file in a target dir, assuming that is a Dataverse development setup
 if [ -f dataverse/target/dataverse/dataset.xhtml ]; then
-  echo "dataset.xhtml exists in target dir, copying assuming Dataverse development setup..."
+  echo "dataset.xhtml exists in target dir, NOT copying assuming Dataverse development setup..."
 else
   echo "dataset.xhtml does not exist in target dir, copying to dataverse container..."
-  docker cp utils/dataverse/mounts/dataset.xhtml "$DATAVERSE_CONTAINER:/opt/payara/deployments/dataverse/dataset.xhtml"
+  #docker cp utils/dataverse/mounts/dataset.xhtml "$DATAVERSE_CONTAINER:/opt/payara/deployments/dataverse/dataset.xhtml"
+  sh utils/dataverse/mounts/update.sh "$DATAVERSE_CONTAINER"
 fi
 echo "--- dataset.xhtml copied!"
 

--- a/utils/dataverse/mounts/update.sh
+++ b/utils/dataverse/mounts/update.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# This script addapts the given dataset.xhtml file 
+# in order to remove (comment out) the Files tab and the Versions tab 
+# And then copies that adapted file to the dataverse container
+
+# check if we have the right number of arguments
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <dataverse_container_name>"
+    exit 1
+fi
+DATAVERSE_CONTAINER=$1
+
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CURRENT_DIR="$(pwd)"
+
+cd "$SCRIPT_DIR" || exit 1
+
+# The initial (original) file is copied from the dataverse container, it is the correct version by definition
+docker cp "$DATAVERSE_CONTAINER":/opt/payara/deployments/dataverse/dataset.xhtml ./dataset.xhtml
+
+COMMENT_TAG="ODISSEI commented out this block"
+
+# check if file already contains the comment 
+if grep -q "<!-- $COMMENT_TAG" dataset.xhtml; then
+  echo "dataset.xhtml file already contains the comment: '$COMMENT_TAG', skipping adaptation."
+  echo "Please remove the comments (uncomment) manually if you want to adapt the file again."
+  exit 0
+fi
+
+echo "Starting to adapt dataset.xhtml file..."
+
+awk -v comment_tag="$COMMENT_TAG" '
+BEGIN {
+  # List of tag patterns to comment out (case-sensitive)
+  tags["ui:fragment id=\"uploadFilesOnCreateTab\""]
+  tags["p:tab id=\"versionsTab\""]
+  tags["p:tab id=\"dataFilesTab\""]
+  inblock = 0
+}
+
+{
+  # Start block: check if line contains one of the start tags
+  for (tag in tags) {
+    if ($0 ~ "<" tag) {
+    comment_start="<!-- " comment_tag
+    print comment_start
+      inblock = 1
+      break
+    }
+  }
+
+  # Inside a block, print the line
+  if (inblock) {
+    print
+
+    # End block: look for closing tag
+    for (tag in tags) {
+      split(tag, tparts, " ")
+      endtag = "</" tparts[1] ">"
+      if ($0 ~ endtag) {
+        print "-->"
+        inblock = 0
+        break
+      }
+    }
+    next
+  }
+
+  # Outside a block, print normally
+  print
+}
+' dataset.xhtml > dataset_commented.xhtml
+
+echo "Finished adapting dataset.xhtml file, now copying to dataverse container..."
+
+# Copy the adapted file to the dataverse container
+docker cp dataset_commented.xhtml "$DATAVERSE_CONTAINER:/opt/payara/deployments/dataverse/dataset.xhtml"
+# Remove the temporary file
+#rm dataset_commented.xhtml
+
+cd "$CURRENT_DIR" || exit 1


### PR DESCRIPTION
Related to Jirs issue: https://drivenbydata.atlassian.net/browse/ODSP-276

The files tab and te versions tab on the dataset page must be commented out in the xhtml, this is now done with an awk script. 
